### PR TITLE
fix: use fullname template in nginx proxy config

### DIFF
--- a/templates/default.conf.yml
+++ b/templates/default.conf.yml
@@ -18,12 +18,12 @@ data:
 
       location /api {
           rewrite ^/api/?(.*)$ /$1 break;
-          proxy_pass http://{{ template "praeco.name" . }}-elastalert:3030/;
+          proxy_pass http://{{ template "praeco.fullname" . }}-elastalert:3030/;
       }
 
       location /api-ws {
           rewrite ^/api-ws/?(.*)$ /$1 break;
-          proxy_pass http://{{ template "praeco.name" . }}-elastalert:3333/;
+          proxy_pass http://{{ template "praeco.fullname" . }}-elastalert:3333/;
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Found that when I had multiple praeco installs running, they were all hitting the same elastalert backend. Turned out the nginx config was using `{{ template "praeco.name" . }}` which just gives "praeco-elastalert" for everything, so all traffic was going to the first install.

Swapped it to use `{{ template "praeco.fullname" . }}` instead, which includes the release name so each installation properly points to its own elastalert service. Now API and WebSocket requests from different installs don't all end up at the same place.